### PR TITLE
Fixes Android bug when called before application.android.context is available

### DIFF
--- a/appversion.android.js
+++ b/appversion.android.js
@@ -1,9 +1,9 @@
 var application = require("application");
-var context = application.android.context;
 
 exports.getVersionName = function () {
   return new Promise(function (resolve, reject) {
     try {
+      var context = application.android.context;
       var packageManager = context.getPackageManager();
       resolve(packageManager.getPackageInfo(context.getPackageName(), 0).versionName);
     } catch (ex) {


### PR DESCRIPTION
When called before application.android.context is available, such on startup of app, this module will fail with "Error in appversion.getVersionName: TypeError: Cannot read property 'getPackageManager' of undefined". This changes so that the _current_ application.android.context is used when called, instead of the application.android.context it got when loading the app.
