### PR TITLE
Support for latest nativescript-dev-webpack v0.2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-appversion",
   "version": "1.3.2",
   "description": "Read the version of your NativeScript app",
-  "main": "appversion.js",
+  "main": "appversion",
   "nativescript": {
     "platforms": {
       "ios": "2.3.0",


### PR DESCRIPTION
Fix the plugin package.json based on article from https://docs.nativescript.org/tooling/bundling-with-webpack#referencing-platform-specific-modules-from-packagejson